### PR TITLE
feat (notion): link split entries to Balances page on creation

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -3,9 +3,14 @@ NOTION_API_TOKEN=your_notion_integration_token_here
 EXPENSE_TABLE_DATABASE_ID=your_expense_table_database_id_here
 SPLIT_DETAILS_DATABASE_ID=your_split_details_database_id_here
 
+# Balances Page — the single row in the Balances table that tracks running totals
+# Get this by opening the Balances page in Notion and copying the page ID from the URL
+BALANCES_PAGE_ID=your_balances_page_id_here
+
 # User Configuration
-YOUR_NAME=Stefan Esquivel
-PARTNER_NAME=Lydu
+# YOUR_NAME / PARTNER_NAME must match exactly as they appear in Notion (used for "Paid By" and "Person" fields)
+YOUR_NAME=Jon Doe
+PARTNER_NAME=Jane Doe
 YOUR_USER_ID=your_notion_user_id_here
 PARTNER_USER_ID=partner_notion_user_id_here
 

--- a/.gitignore
+++ b/.gitignore
@@ -48,3 +48,4 @@ Thumbs.db
 .pytest_cache/
 .coverage
 htmlcov/
+.bob/mcp.json

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -71,15 +71,23 @@ The Notion Expense Automation system is a Python-based application that automate
 ┌─────────────────────────────────────────────────────────────────┐
 │                         NOTION API                               │
 │                                                                   │
-│  ┌──────────────────┐              ┌──────────────────────┐    │
-│  │  Expense Table   │◄─────────────┤ Split Details Table  │    │
-│  │                  │   Relation    │                      │    │
-│  │ • Merchant       │               │ • Title              │    │
-│  │ • Date           │               │ • Person (owes)      │    │
-│  │ • Amount         │               │ • Share Amount       │    │
-│  │ • Paid By        │               │ • Date               │    │
-│  │ • Receipt        │               │ • Balances (link)    │    │
-│  └──────────────────┘               └──────────────────────┘    │
+│  ┌──────────────────┐   Relation   ┌──────────────────────┐    │
+│  │  Expense Table   │◄─────────────┤  Split Details Table │    │
+│  │                  │              │                      │    │
+│  │ • Merchant       │              │ • Title              │    │
+│  │ • Date           │              │ • Person (owes)      │    │
+│  │ • Amount         │              │ • Share Amount       │    │
+│  │ • Paid By        │              │ • Share Percent      │    │
+│  │ • Receipt        │              └──────────┬───────────┘    │
+│  └──────────────────┘                         │ Relation        │
+│                                               ▼                  │
+│                                  ┌──────────────────────┐       │
+│                                  │   Balances Table     │       │
+│                                  │  (single page/row)   │       │
+│                                  │                      │       │
+│                                  │ • Running totals     │       │
+│                                  │ • Linked splits      │       │
+│                                  └──────────────────────┘       │
 └─────────────────────────────────────────────────────────────────┘
                               │
                               ▼
@@ -113,8 +121,9 @@ The Notion Expense Automation system is a Python-based application that automate
 
 **Key Configuration**:
 - Notion API credentials
-- Database IDs
-- User names
+- Database IDs (`EXPENSE_TABLE_DATABASE_ID`, `SPLIT_DETAILS_DATABASE_ID`, `BALANCES_DATABASE_ID`)
+- Balances page ID (`BALANCES_PAGE_ID`) — the single row in the Balances table
+- User name aliases (`YOUR_NAME`, `PARTNER_NAME`) — must match Notion field values exactly
 - Folder paths
 - Split percentage
 
@@ -150,21 +159,29 @@ The Notion Expense Automation system is a Python-based application that automate
 YYYY-MM-DD_Merchant_Description_$Amount.pdf
 ```
 
-### 4. Notion Client (`src/notion_client.py`)
+### 4. Notion Client (`src/notion_api.py`)
 **Purpose**: Interface with Notion API
 
 **Responsibilities**:
 - Create expense table entries
 - Create split details entries
-- Link split entries to expense entries
+- Link pages via relations using the generic `_link_pages(source, target, property_name)` method
+- Link split entries to their parent expense entry (`"Split Details Table"` relation)
+- Link split entries to the single Balances page (`"Split Details Table"` relation on the balance page)
 - Generate split titles following naming patterns
 - Test API connection
 - Handle API errors
 
-**Split Title Patterns**:
-- Food: `"[Person]'s Walmart Food Split (Item)"`
-- Bills: `"[Person]'s Electrical Bill Split (Month)"`
-- Subscriptions: `"[Person]'s Netflix Payment (Month)"`
+**Key Design — `_link_pages()`**:
+- Generic method: takes `source_page_id`, `target_page_id`, and `table_name` (the relation property name)
+- Fetches existing relations first to avoid overwriting them (append-safe)
+- Deduplicates before updating
+- Used for both expense→split and balance→split links
+
+**Split Title Patterns** (uses name aliases from `YOUR_NAME` / `PARTNER_NAME`):
+- Food: `"[Alias]'s Walmart Food Split (Item)"`
+- Bills: `"[Alias]'s Electrical Bill Split (Month)"`
+- Subscriptions: `"[Alias]'s Netflix Payment (Month)"`
 
 ### 5. User Interface (`src/ui.py`)
 **Purpose**: Handle all user interactions
@@ -223,27 +240,32 @@ Parsed Data → User Review → Confirmed Data → Notion Entries
 
 ## Split Logic
 
-### Scenario: You pay $100 at Walmart
+### Scenario: YOU pay $100 at Walmart
 
 **Input**:
 - Amount: $100.00
-- Paid By: Stefan Esquivel
+- Paid By: `YOU` (your alias from `YOUR_NAME`)
 
 **Processing**:
 - Calculate split: $100.00 × 50% = $50.00
-- Non-payer: Lydu
+- Non-payer: `PARTNER` (your alias from `PARTNER_NAME`)
 
 **Output**:
 1. **Expense Entry**:
    - Merchant: "Walmart Order"
    - Amount: CA$100.00
-   - Paid By: Stefan Esquivel
+   - Paid By: `YOU`
+   - Linked to: Split entry (via `"Split Details Table"` relation)
 
 2. **Split Entry** (ONE entry only):
-   - Title: "Lydia's Walmart Food Split"
-   - Person: Lydu
+   - Title: "`PARTNER`'s Walmart Food Split"
+   - Person: `PARTNER`
    - Share Amount: CA$50.00
-   - Meaning: Lydu owes Stefan $50.00
+   - Meaning: `PARTNER` owes `YOU` $50.00
+   - Linked to: Expense entry AND Balances page
+
+3. **Balances Page** (single row, updated):
+   - New split entry appended to `"Split Details Table"` relation
 
 ## Error Handling
 

--- a/README.md
+++ b/README.md
@@ -58,10 +58,17 @@ pip install -r requirements.txt
    ```
 4. Repeat for Split Details Table
 
+#### Get the Balances Page ID:
+1. Open your Balances Table in Notion
+2. Click into the single row (the balances page)
+3. Click "Share" → "Copy link"
+4. Extract the page ID from the URL (the long string after the last `/`)
+
 #### Connect Integration to Databases:
-1. Open each database in Notion
+1. Open each database in Notion (Expense Table, Split Details Table, Balances Table)
 2. Click "•••" (top right) → "Add connections"
 3. Select your "Expense Automation" integration
+   > Note: The Balances Table connection is still needed for the Balances Page ID to work.
 
 ### 5. Configure Environment Variables
 
@@ -78,8 +85,12 @@ NOTION_API_TOKEN=secret_xxxxxxxxxxxxxxxxxxxxx
 EXPENSE_TABLE_DATABASE_ID=xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
 SPLIT_DETAILS_DATABASE_ID=xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
 
-YOUR_NAME=Stefan Esquivel
-PARTNER_NAME=Lydu
+# The single row in your Balances table (page ID, not database ID)
+BALANCES_PAGE_ID=xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
+
+# Use aliases — these don't have to be real names
+YOUR_NAME=You
+PARTNER_NAME=Partner
 
 INPUT_FOLDER=receipts/input
 PROCESSED_FOLDER=receipts/processed
@@ -115,6 +126,7 @@ The system will:
 
 - **Expense Table**: New entry with merchant, date, amount, and payer
 - **Split Details Table**: Linked entry showing the other person's share (debt)
+- **Balances Table**: Split entry linked to the single Balances page to update running totals
 - **Organized Files**: Receipts moved to `receipts/processed/YYYY-MM/` with descriptive names
 
 ## Workflow Example
@@ -124,13 +136,14 @@ The system will:
 **Process:**
 1. System extracts: "Walmart Order - $92.01 - Jan 18, 2026"
 2. You review and confirm the information
-3. You select: "Stefan Esquivel" paid
-4. System calculates: Lydia owes $46.01
+3. You select: `YOU` paid (your alias from `YOUR_NAME`)
+4. You confirm the split percentage (default 50%)
 5. You confirm and send to Notion
 
 **Output:**
-- **Expense Entry**: "Walmart Order" - CA$92.01 - Paid by Stefan
-- **Split Entry**: "Lydia's Walmart Food Split" - CA$46.01 owed by Lydia
+- **Expense Entry**: "Walmart Order" - CA$92.01 - Paid by `YOU`
+- **Split Entry**: "`PARTNER`'s Walmart Food Split" - 50% share — Notion calculates the dollar amount via rollup from the Expense entry
+- **Balances Entry**: Split linked to the Balances page
 - **File**: Moved to `receipts/processed/2026-01/2026-01-18_Walmart_Order_$92.01.pdf`
 
 ## File Structure
@@ -172,12 +185,12 @@ The system automatically detects and categorizes:
 
 ## Split Title Patterns
 
-The system generates split titles following your existing Notion patterns:
+The system generates split titles following your existing Notion patterns (using your configured name aliases):
 
-- Food: "Lydia's Walmart Food Split (Shrimp)"
-- Bills: "Stefan's Electrical Bill Split (Jan)"
-- Subscriptions: "Lydia's Netflix Payment (Feb)"
-- Rent: "Stefan's Rent Split (Feb)"
+- Food: "`PARTNER`'s Walmart Food Split (Shrimp)"
+- Bills: "`YOU`'s Electrical Bill Split (Jan)"
+- Subscriptions: "`PARTNER`'s Netflix Payment (Feb)"
+- Rent: "`YOU`'s Rent Split (Feb)"
 
 ## Troubleshooting
 

--- a/SETUP_GUIDE.md
+++ b/SETUP_GUIDE.md
@@ -6,7 +6,7 @@ This guide will walk you through setting up the Notion Expense Automation system
 
 - [ ] Python 3.8+ installed on your computer
 - [ ] Notion account with workspace access
-- [ ] Existing Expense Table and Split Details Table in Notion
+- [ ] Existing Expense Table, Split Details Table, and Balances Table in Notion
 - [ ] PDF receipts ready to process
 
 ## Step 1: Notion Integration Setup
@@ -39,9 +39,22 @@ This guide will walk you through setting up the Notion Expense Automation system
 3. Extract the database ID from the URL (same format as above)
 4. Save this ID
 
+#### For Balances Table:
+1. Open your **Balances Table** in Notion
+2. Click **"Share"** → **"Copy link"**
+3. Extract the database ID from the URL
+4. Save this ID
+
+#### For Balances Page ID:
+1. Open your **Balances Table** in Notion
+2. Click into the **single row** (the balances tracking page)
+3. Click **"Share"** → **"Copy link"**
+4. The page ID is the long string at the end of the URL (after the last `/`, before any `?`)
+5. Save this ID — this is different from the database ID above
+
 ### 1.3 Connect Integration to Databases
 
-**For EACH database (Expense Table and Split Details Table):**
+**For EACH database (Expense Table, Split Details Table, and Balances Table):**
 
 1. Open the database in Notion
 2. Click the **"•••"** menu (top right corner)
@@ -104,16 +117,23 @@ Open `.env` in a text editor and fill in your values:
 NOTION_API_TOKEN=secret_xxxxxxxxxxxxxxxxxxxxx
 
 # Paste your Expense Table database ID from Step 1.2
-EXPENSE_TABLE_DATABASE_ID=27361377bcc3807b883be5176931dea4
+EXPENSE_TABLE_DATABASE_ID=xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
 
 # Paste your Split Details Table database ID from Step 1.2
-SPLIT_DETAILS_DATABASE_ID=27361377bcc3805b8815cc38f890f30f
+SPLIT_DETAILS_DATABASE_ID=xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
 
-# Your name (as it appears in Notion)
-YOUR_NAME=Stefan Esquivel
+# Paste your Balances Table database ID from Step 1.2
+BALANCES_DATABASE_ID=xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
 
-# Your partner's name (as it appears in Notion)
-PARTNER_NAME=Lydu
+# Paste the single Balances row page ID from Step 1.2
+BALANCES_PAGE_ID=xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
+
+# Your name alias — used in split titles and to match Notion "Paid By" / "Person" fields
+# Can be any alias, but must match exactly what's in Notion
+YOUR_NAME=You
+
+# Your partner's name alias — same rules as above
+PARTNER_NAME=Partner
 
 # Leave these as default or customize
 INPUT_FOLDER=receipts/input
@@ -123,8 +143,9 @@ DEFAULT_SPLIT_PERCENTAGE=50.0
 
 **Important Notes:**
 - Replace `secret_xxxxx` with your actual token
-- Replace the database IDs with your actual IDs
-- Names must match exactly as they appear in your Notion "Paid By" and "Person" fields
+- Replace all IDs with your actual values
+- `YOUR_NAME` and `PARTNER_NAME` are aliases — they must match exactly what appears in your Notion "Paid By" and "Person" fields
+- `BALANCES_PAGE_ID` is a **page ID** (a specific row), not a database ID
 - Don't add quotes around values
 
 ### 3.3 Verify Folder Structure
@@ -165,9 +186,10 @@ The application will:
 
 ### 4.4 Verify in Notion
 
-1. Open your **Expense Table** - you should see a new entry
-2. Open your **Split Details Table** - you should see a linked split entry
-3. Check that the amounts are correct (50/50 split by default)
+1. Open your **Expense Table** — you should see a new entry
+2. Open your **Split Details Table** — you should see a linked split entry
+3. Open your **Balances Table** — the single row should now link to the new split entry
+4. Check that the amounts are correct (50/50 split by default)
 
 ## Step 5: Daily Usage
 

--- a/src/config.py
+++ b/src/config.py
@@ -13,10 +13,11 @@ class Config:
     NOTION_API_TOKEN = os.getenv('NOTION_API_TOKEN')
     EXPENSE_TABLE_DATABASE_ID = os.getenv('EXPENSE_TABLE_DATABASE_ID')
     SPLIT_DETAILS_DATABASE_ID = os.getenv('SPLIT_DETAILS_DATABASE_ID')
+    BALANCES_PAGE_ID = os.getenv('BALANCES_PAGE_ID')
     
     # User Configuration
-    YOUR_NAME = os.getenv('YOUR_NAME', 'Stefan Esquivel')
-    PARTNER_NAME = os.getenv('PARTNER_NAME', 'Lydu')
+    YOUR_NAME = os.getenv('YOUR_NAME', 'You')
+    PARTNER_NAME = os.getenv('PARTNER_NAME', 'Partner')
     YOUR_USER_ID = os.getenv('YOUR_USER_ID', 'a20139cd-f446-493b-936f-05cf7f715835')
     PARTNER_USER_ID = os.getenv('PARTNER_USER_ID', 'a9e310cd-1c5b-4cea-8bad-7381b60d7144')
     
@@ -29,6 +30,10 @@ class Config:
     # Split Configuration
     DEFAULT_SPLIT_PERCENTAGE = float(os.getenv('DEFAULT_SPLIT_PERCENTAGE', '50.0'))
     
+    # Notion relation property names
+    EXPENSE_RELATION_PROPERTY = "Split Details Table"   # relation property name on Expense Table pages
+    BALANCES_RELATION_PROPERTY = "Split Details Table"  # relation property name on Balances page
+    
     @classmethod
     def validate(cls):
         """Validate that all required configuration is present."""
@@ -40,6 +45,8 @@ class Config:
             errors.append("EXPENSE_TABLE_DATABASE_ID is not set")
         if not cls.SPLIT_DETAILS_DATABASE_ID:
             errors.append("SPLIT_DETAILS_DATABASE_ID is not set")
+        if not cls.BALANCES_PAGE_ID:
+            errors.append("BALANCES_PAGE_ID is not set")
             
         if errors:
             raise ValueError(f"Configuration errors:\n" + "\n".join(f"  - {e}" for e in errors))

--- a/src/main.py
+++ b/src/main.py
@@ -40,7 +40,8 @@ class ExpenseAutomation:
         self.notion_client = NotionExpenseClient(
             Config.NOTION_API_TOKEN,
             Config.EXPENSE_TABLE_DATABASE_ID,
-            Config.SPLIT_DETAILS_DATABASE_ID
+            split_db_id=Config.SPLIT_DETAILS_DATABASE_ID,
+            balance_page_id=Config.BALANCES_PAGE_ID
         )
     
     def process_receipt(self, pdf_path: Path) -> bool:

--- a/src/notion_api.py
+++ b/src/notion_api.py
@@ -15,11 +15,12 @@ NOTION_VERSION = "2025-09-03"
 class NotionExpenseClient:
     """Handle all Notion API operations for expense tracking."""
     
-    def __init__(self, api_token: str, expense_db_id: str, split_db_id: str):
+    def __init__(self, api_token: str, expense_db_id: str, split_db_id: str, balance_page_id: str):
         self.client = Client(auth=api_token)
         self.api_token = api_token
         self.expense_db_id = expense_db_id
         self.split_db_id = split_db_id
+        self.balance_page_id = balance_page_id
         
         # Map person names to Notion user IDs
         self.user_id_map = {
@@ -214,30 +215,45 @@ class NotionExpenseClient:
             )
             split_page_id = response["id"]
             
-            # Link the split entry to the expense entry
-            self._link_split_to_expense(expense_page_id, split_page_id)
+            # Link the split entry to the expense entry (critical: orphaned split is a data integrity issue)
+            self._link_pages(source_page_id=expense_page_id, target_page_id=split_page_id, table_name=Config.EXPENSE_RELATION_PROPERTY, critical=True)
+
+            # Link the split entry to the balance entry (non-critical: warn only)
+            self._link_pages(source_page_id=self.balance_page_id, target_page_id=split_page_id, table_name=Config.BALANCES_RELATION_PROPERTY, critical=False)
             
             return split_page_id
         except APIResponseError as e:
             raise Exception(f"Failed to create split entry: {e}")
     
-    def _link_split_to_expense(self, expense_page_id: str, split_page_id: str):
-        """Link a split details entry to its parent expense entry."""
+    def _link_pages(self, source_page_id: str, target_page_id: str, table_name: str, critical: bool = False):
+        """Append target_page_id to the relation property `table_name` on source_page_id, deduplicating existing entries.
+
+        Args:
+            critical: If True, re-raises APIResponseError on failure instead of only warning.
+        """
         try:
-            # Update the expense entry to link to the split
+            # Get existing relations
+            page = self.client.pages.retrieve(page_id=source_page_id)
+            existing_relations = page["properties"][table_name]["relation"]
+
+            # Avoid duplicates
+            existing_ids = {r["id"] for r in existing_relations}
+            if target_page_id not in existing_ids:
+                existing_relations.append({"id": target_page_id})
+
+            # Send full updated list
             self.client.pages.update(
-                page_id=expense_page_id,
+                page_id=source_page_id,
                 properties={
-                    "Split Details Table": {
-                        "relation": [
-                            {"id": split_page_id}
-                        ]
+                    table_name: {
+                        "relation": existing_relations
                     }
                 }
             )
-        except APIResponseError as e:
-            # Non-critical error, log but don't fail
-            print(f"Warning: Failed to link split to expense: {e}")
+        except (APIResponseError, KeyError) as e:
+            if critical:
+                raise Exception(f"Failed to link source page {source_page_id} to target page {target_page_id}: {e}")
+            print(f"Warning: Failed to link source page {source_page_id} to target page {target_page_id}: {e}")
     
     def generate_split_title(
         self,
@@ -298,6 +314,7 @@ class NotionExpenseClient:
             # Try to retrieve database info
             self.client.databases.retrieve(database_id=self.expense_db_id)
             self.client.databases.retrieve(database_id=self.split_db_id)
+            self.client.pages.retrieve(page_id=self.balance_page_id)
             return True
         except APIResponseError as e:
             print(f"Notion API connection test failed: {e}")


### PR DESCRIPTION
- Split entries now linked to the fixed Balances page via _link_pages()
- Added BALANCES_DATABASE_ID and BALANCES_PAGE_ID to Config and .env

Closes: Link Split entries to Balance page for rollup tracking Fixes #7