### PR TITLE
fix(#33): extract real total from Walmart receipts with temporary hold

### DIFF
--- a/src/services/pdf_extractor.py
+++ b/src/services/pdf_extractor.py
@@ -82,25 +82,46 @@ class PDFExtractor:
         return ('unknown', 'Unknown Merchant')
     
     def extract_amount(self, text: str) -> Optional[float]:
-        """Extract the total amount from receipt text."""
-        # Look for common patterns: $XX.XX, CA$XX.XX, Total: $XX.XX
-        patterns = [
+        """Extract the total amount from receipt text.
+
+        Strategy:
+        1. Look for an amount on a line explicitly labelled 'Total' / 'Grand Total' /
+           'Amount', skipping any line that also contains 'hold' or 'temporary'
+           (e.g. Walmart's 'Temporary hold' lines).
+        2. Fall back to the largest amount found in the document if no clean
+           labelled total is present.
+        """
+        # --- Pass 1: labelled total on a non-hold line ---
+        # Use \b so that 'Subtotal' does NOT match — only a standalone 'Total' / 'Grand Total' / 'Amount' word.
+        labelled_pattern = re.compile(
+            r'\b(?:grand total|total|amount)\b[\s:]*(?:CA)?\$?\s*(\d+[,\d]*\.?\d{2})',
+            re.IGNORECASE,
+        )
+        for line in text.splitlines():
+            # Skip lines that are temporary holds or discounts
+            if re.search(r'(temporary|hold)', line, re.IGNORECASE):
+                continue
+            match = labelled_pattern.search(line)
+            if match:
+                try:
+                    return float(match.group(1).replace(',', ''))
+                except ValueError:
+                    continue
+
+        # --- Pass 2: fallback — collect all amounts and return the largest ---
+        fallback_patterns = [
             r'(?:total|amount|grand total)[\s:]*(?:CA)?\$?\s*(\d+[,\d]*\.?\d{2})',
             r'(?:CA)?\$\s*(\d+[,\d]*\.\d{2})',
             r'(\d+[,\d]*\.\d{2})\s*(?:CAD|CA\$)',
         ]
-        
         amounts = []
-        for pattern in patterns:
-            matches = re.finditer(pattern, text, re.IGNORECASE)
-            for match in matches:
-                amount_str = match.group(1).replace(',', '')
+        for pattern in fallback_patterns:
+            for match in re.finditer(pattern, text, re.IGNORECASE):
                 try:
-                    amounts.append(float(amount_str))
+                    amounts.append(float(match.group(1).replace(',', '')))
                 except ValueError:
                     continue
-        
-        # Return the largest amount found (likely the total)
+
         return max(amounts) if amounts else None
     
     def extract_date(self, text: str) -> Optional[datetime]:

--- a/test/unit/test_pdf_extractor.py
+++ b/test/unit/test_pdf_extractor.py
@@ -134,6 +134,34 @@ class TestPDFExtractor:
         amount = extractor.extract_amount(text)
         
         assert amount is None
+
+    def test_extract_amount_walmart_with_temporary_hold(self, extractor):
+        """Bug #33: Walmart receipts with a 'Temporary hold' must return the real total."""
+        text = (
+            "Subtotal $62.38\n"
+            "Taxes $3.03\n"
+            "Total $65.41\n"
+            "Temporary hold $68.29\n"
+            "Temporary hold\n"
+            "$68.29\n"
+        )
+        amount = extractor.extract_amount(text)
+
+        assert amount == 65.41, f"Expected 65.41 (real total) but got {amount}"
+
+    def test_extract_amount_hold_higher_than_total_still_returns_total(self, extractor):
+        """Bug #33: Temporary hold value higher than total must not win."""
+        text = "Total $100.00\nTemporary hold $110.00"
+        amount = extractor.extract_amount(text)
+
+        assert amount == 100.00
+
+    def test_extract_amount_no_hold_still_works(self, extractor):
+        """Regression: normal receipts without a hold still extract correctly."""
+        text = "Subtotal $72.68\nTaxes $4.32\nTotal $80.59"
+        amount = extractor.extract_amount(text)
+
+        assert amount == 80.59
     
     def test_detect_merchant_walmart(self, extractor):
         """Test Walmart merchant detection"""


### PR DESCRIPTION
- Replace max(amounts) with a two-pass strategy in extract_amount()
- Pass 1: match standalone \bTotal\b / \bGrand Total\b / \bAmount\b line-by-line, skipping any line containing 'temporary' or 'hold'
- Pass 2: fallback to max(amounts) for receipts without a labelled total
- Word boundary on label pattern prevents Subtotal from matching Total
- Add 3 new unit tests covering the bug scenario and regressions